### PR TITLE
Fix HTML meta tag to be HTML5 compliant by removing the closing slash…

### DIFF
--- a/dash/dash.py
+++ b/dash/dash.py
@@ -288,7 +288,7 @@ class Dash(object):
         <!DOCTYPE html>
         <html>
             <head>
-                <meta charset="UTF-8"/>
+                <meta charset="UTF-8">
                 <title>{}</title>
                 {}
             </head>


### PR DESCRIPTION
… as seen on https://developer.mozilla.org/en-US/docs/Web/HTML/Element/meta